### PR TITLE
Pass child's instance number into child's __invoke() method

### DIFF
--- a/library/JobInterface.php
+++ b/library/JobInterface.php
@@ -4,7 +4,7 @@ namespace ryancco\forker;
 
 interface JobInterface
 {
-    public function __invoke($instanceNumber);
+    public function __invoke($instanceNumber = 1);
 
     public function __destruct();
 }

--- a/library/JobInterface.php
+++ b/library/JobInterface.php
@@ -4,7 +4,7 @@ namespace ryancco\forker;
 
 interface JobInterface
 {
-    public function __invoke();
+    public function __invoke($instanceNumber);
 
     public function __destruct();
 }


### PR DESCRIPTION
Useful value for children that are attempting processes such as modulo